### PR TITLE
Prepend v to the version tag and release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: "$RESOLVED_VERSION"
-tag-template: "$RESOLVED_VERSION"
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "🚀 Features"
     labels:


### PR DESCRIPTION
## Description
GitHub Actions by convention start with `v0.0.0`. This just makes sure release drafter raises releases in that format, instead of `0.0.0`