### PR TITLE
Remove reviewers dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - "mention-me/partnerships"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - "mention-me/partnerships"


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/